### PR TITLE
refactor: defer calendar service import

### DIFF
--- a/services/google/calendar_sync.py
+++ b/services/google/calendar_sync.py
@@ -23,7 +23,6 @@ from googleapiclient.discovery import build
 
 from utils.time_utils import parse_calendar_datetime
 from pymongo import UpdateOne
-from services.calendar_service import CalendarService, SyncTokenExpired as ServiceSyncTokenExpired
 
 # ---------------------------------------------------------------------------
 # Logging setup
@@ -234,6 +233,11 @@ def sync_to_mongodb(
     time_max: Optional[datetime] = None,
 ) -> int:
     """Fetch events via :class:`CalendarService` and upsert them into MongoDB."""
+
+    from services.calendar_service import (
+        CalendarService,
+        SyncTokenExpired as ServiceSyncTokenExpired,
+    )
 
     svc = CalendarService()
     if time_min is None:


### PR DESCRIPTION
## Summary
- defer `CalendarService` import in `calendar_sync.sync_to_mongodb` to avoid eager circular dependency

## Testing
- `black --check .`
- `flake8`
- `pytest` *(fails: 32 failed, 158 passed)*
- `SECRET_KEY=1 DISCORD_TOKEN=x DISCORD_GUILD_ID=1 REMINDER_CHANNEL_ID=1 DISCORD_CLIENT_ID=x DISCORD_CLIENT_SECRET=x DISCORD_REDIRECT_URI=http://localhost GOOGLE_CLIENT_ID=x GOOGLE_CLIENT_SECRET=x SESSION_LIFETIME_MINUTES=60 R3_ROLE_IDS=0 R4_ROLE_IDS=0 ADMIN_ROLE_IDS=0 MONGODB_URI=mongodb://localhost:27017 python main_app.py` *(MongoDB connection failed: localhost:27017: [Errno 111] Connection refused (configured timeouts: socketTimeoutMS: 20000.0ms, connectTimeoutMS: 20000.0ms), Timeout: 5.0s, Topology Description: <TopologyDescription id: 68983f876224a6dcd40dad6b, topology_type: Unknown, servers: [<ServerDescription ('localhost', 27017) server_type: Unknown, rtt: None, error=AutoReconnect('localhost:27017: [Errno 111] Connection refused (configured timeouts: socketTimeoutMS: 20000.0ms, connectTimeoutMS: 20000.0ms)')>]>)*

------
https://chatgpt.com/codex/tasks/task_e_68983e4d959c83249088d9e5ac8c4b23