### PR TITLE
refactor: replace Config with ConfigDict

### DIFF
--- a/models/event_model.py
+++ b/models/event_model.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from bson import ObjectId
 from motor.motor_asyncio import AsyncIOMotorCollection
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class PyObjectId(ObjectId):
@@ -30,10 +30,11 @@ class EventModel(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        allow_population_by_field_name = True
-        arbitrary_types_allowed = True
-        json_encoders = {ObjectId: str}
+    model_config = ConfigDict(
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+        json_encoders={ObjectId: str},
+    )
 
 
 class EventRepository:

--- a/models/models_mongo.py
+++ b/models/models_mongo.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 from bson import ObjectId
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 
 # ➕ Custom ObjectId Type für Pydantic-Kompatibilität
@@ -32,11 +32,11 @@ class UserModel(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        allow_population_by_field_name = True
-        arbitrary_types_allowed = True
-        json_encoders = {ObjectId: str}
-        schema_extra = {
+    model_config = ConfigDict(
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+        json_encoders={ObjectId: str},
+        schema_extra={
             "example": {
                 "discord_id": "123456789012345678",
                 "username": "FURUser",
@@ -44,4 +44,5 @@ class UserModel(BaseModel):
                 "email": "user@example.com",
                 "role_level": "R3",
             }
-        }
+        },
+    )

--- a/models/user_model.py
+++ b/models/user_model.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from bson import ObjectId
 from motor.motor_asyncio import AsyncIOMotorCollection
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class PyObjectId(ObjectId):
@@ -28,10 +28,11 @@ class UserModel(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        allow_population_by_field_name = True
-        arbitrary_types_allowed = True
-        json_encoders = {ObjectId: str}
+    model_config = ConfigDict(
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+        json_encoders={ObjectId: str},
+    )
 
 
 class UserRepository:

--- a/schemas/event_schema.py
+++ b/schemas/event_schema.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import List, Optional
 
 from bson import ObjectId
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, ConfigDict, Field, validator
 
 
 # Hilfsklasse zur Unterstützung von ObjectId in Pydantic
@@ -46,7 +46,8 @@ class EventModel(BaseModel):
             raise ValueError("Datum muss im ISO-Format sein (z. B. 2025-06-20T18:00:00)")
         return v
 
-    class Config:
-        allow_population_by_field_name = True
-        arbitrary_types_allowed = True
-        json_encoders = {ObjectId: str}
+    model_config = ConfigDict(
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+        json_encoders={ObjectId: str},
+    )

--- a/schemas/participant_schema.py
+++ b/schemas/participant_schema.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 from bson import ObjectId
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from models.models_mongo import PyObjectId
 
@@ -13,7 +13,8 @@ class ParticipantModel(BaseModel):
     user_id: str
     joined_at: Optional[datetime] = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        allow_population_by_field_name = True
-        arbitrary_types_allowed = True
-        json_encoders = {ObjectId: str, datetime: lambda v: v.isoformat()}
+    model_config = ConfigDict(
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+        json_encoders={ObjectId: str, datetime: lambda v: v.isoformat()},
+    )

--- a/schemas/reminder_schema.py
+++ b/schemas/reminder_schema.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import List, Optional
 
 from bson import ObjectId
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, ConfigDict, Field, validator
 
 from models.models_mongo import PyObjectId
 
@@ -24,7 +24,8 @@ class ReminderModel(BaseModel):
             raise ValueError("Zeit muss im ISO-Format sein (z. B. 2025-06-25T19:00:00)")
         return v
 
-    class Config:
-        allow_population_by_field_name = True
-        arbitrary_types_allowed = True
-        json_encoders = {ObjectId: str}
+    model_config = ConfigDict(
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+        json_encoders={ObjectId: str},
+    )

--- a/schemas/user_schema.py
+++ b/schemas/user_schema.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 from bson import ObjectId
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class PyObjectId(ObjectId):
@@ -29,7 +29,8 @@ class UserModel(BaseModel):
     created_at: Optional[datetime] = Field(default_factory=datetime.utcnow)
     updated_at: Optional[datetime] = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        allow_population_by_field_name = True
-        arbitrary_types_allowed = True
-        json_encoders = {ObjectId: str, datetime: lambda v: v.isoformat()}
+    model_config = ConfigDict(
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+        json_encoders={ObjectId: str, datetime: lambda v: v.isoformat()},
+    )


### PR DESCRIPTION
## Summary
- use `ConfigDict(populate_by_name=True)` across models and schemas to replace deprecated `Config`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'googleapiclient', 'discord')*
- `black --check .`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_68983feea79083249e090a3b99876486