### PR TITLE
Refactor calendar services to accept injected settings

### DIFF
--- a/bot/cogs/calendar_cog.py
+++ b/bot/cogs/calendar_cog.py
@@ -3,6 +3,8 @@ import secrets
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
+import os
+
 import discord
 from discord import app_commands
 from discord.ext import commands, tasks
@@ -11,6 +13,7 @@ from config import Config
 from fur_lang.i18n import t
 from mongo_service import get_collection
 from services.calendar_service import CalendarService
+from services.google.calendar_sync import CalendarSettings
 from utils.poster_generator import create_event_image
 from utils.oauth_utils import (
     build_authorization_url,
@@ -39,7 +42,13 @@ class CalendarCog(commands.Cog):
 
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        self.service = CalendarService()
+        settings = CalendarSettings()
+        self.service = CalendarService(
+            calendar_id=settings.calendar_id,
+            token_path=str(settings.token_path),
+            scopes=settings.scopes,
+            mongo_uri=os.getenv("MONGODB_URI"),
+        )
         self.sync_loop.start()
         self.daily_loop.start()
         self.weekly_loop.start()

--- a/tests/test_calendar_cog_context.py
+++ b/tests/test_calendar_cog_context.py
@@ -1,0 +1,50 @@
+import importlib
+import pathlib
+import sys
+import types
+
+import pytest
+
+services_pkg = types.ModuleType("services")
+services_pkg.__path__ = [str(pathlib.Path(__file__).resolve().parents[1] / "services")]
+sys.modules["services"] = services_pkg
+
+calendar_cog = importlib.import_module("bot.cogs.calendar_cog")
+
+
+@pytest.mark.asyncio
+async def test_calendar_cog_loops_without_app_context(monkeypatch):
+    monkeypatch.setattr(calendar_cog.tasks.Loop, "start", lambda self: None)
+
+    async def ready():
+        return None
+
+    bot = types.SimpleNamespace(
+        wait_until_ready=ready, get_guild=lambda gid: types.SimpleNamespace(members=[])
+    )
+    cog = calendar_cog.CalendarCog(bot)
+
+    class DummyService:
+        def __init__(self) -> None:
+            self.service = object()
+
+        def _build_service(self) -> None:
+            pass
+
+        async def sync(self) -> None:
+            return None
+
+        async def get_events_today(self):
+            return []
+
+        async def get_events_week(self):
+            return []
+
+    cog.service = DummyService()
+
+    monkeypatch.setattr(calendar_cog, "should_send_daily", lambda dt: False)
+    monkeypatch.setattr(calendar_cog, "should_send_weekly", lambda dt: False)
+
+    await cog.sync_loop()
+    await cog.daily_loop()
+    await cog.weekly_loop()

--- a/tests/test_reminder_autopilot_context.py
+++ b/tests/test_reminder_autopilot_context.py
@@ -1,0 +1,25 @@
+import importlib
+import pathlib
+import sys
+import types
+
+import pytest
+
+services_pkg = types.ModuleType("services")
+services_pkg.__path__ = [str(pathlib.Path(__file__).resolve().parents[1] / "services")]
+sys.modules["services"] = services_pkg
+
+autopilot_mod = importlib.import_module("bot.cogs.reminder_autopilot")
+
+
+@pytest.mark.asyncio
+async def test_reminder_autopilot_runs_without_app_context(monkeypatch):
+    monkeypatch.setattr(autopilot_mod.tasks.Loop, "start", lambda self: None)
+    bot = types.SimpleNamespace()
+    cog = autopilot_mod.ReminderAutopilot(bot)
+
+    monkeypatch.setattr(autopilot_mod, "get_service", lambda settings: object())
+    monkeypatch.setattr(autopilot_mod, "list_upcoming_events", lambda *a, **k: [])
+    monkeypatch.setattr(autopilot_mod, "is_production", lambda: True)
+
+    await cog.run_reminder_check()


### PR DESCRIPTION
## Summary
- decouple Google Calendar helpers from Flask `current_app` by introducing `CalendarSettings`
- allow `CalendarService` to accept token path, calendar ID and other options
- update ReminderAutopilot and CalendarCog to pass configuration directly
- add tests ensuring ReminderAutopilot and CalendarCog loops run without Flask app context

## Testing
- `black --check .`
- `flake8`
- `pytest tests/test_reminder_autopilot_context.py tests/test_calendar_cog_context.py`


------
https://chatgpt.com/codex/tasks/task_e_6898435e91448324b4fae3008673eee5