### PR TITLE
calendar: initialize CalendarService within app context

### DIFF
--- a/tests/test_calendar_cog_context.py
+++ b/tests/test_calendar_cog_context.py
@@ -4,12 +4,24 @@ import sys
 import types
 
 import pytest
+from flask import Flask, has_app_context
 
 services_pkg = types.ModuleType("services")
 services_pkg.__path__ = [str(pathlib.Path(__file__).resolve().parents[1] / "services")]
 sys.modules["services"] = services_pkg
 
+main_app_pkg = types.ModuleType("main_app")
+main_app_pkg.app = Flask("test")
+sys.modules["main_app"] = main_app_pkg
+
 calendar_cog = importlib.import_module("bot.cogs.calendar_cog")
+
+
+@pytest.mark.asyncio
+async def test_calendar_cog_initializes_without_service(monkeypatch):
+    monkeypatch.setattr(calendar_cog.tasks.Loop, "start", lambda self: None)
+    cog = calendar_cog.CalendarCog(types.SimpleNamespace())
+    assert cog.service is None
 
 
 @pytest.mark.asyncio
@@ -48,3 +60,34 @@ async def test_calendar_cog_loops_without_app_context(monkeypatch):
     await cog.sync_loop()
     await cog.daily_loop()
     await cog.weekly_loop()
+
+
+@pytest.mark.asyncio
+async def test_sync_loop_builds_service_with_app_context(monkeypatch):
+    monkeypatch.setattr(calendar_cog.tasks.Loop, "start", lambda self: None)
+
+    called: dict[str, bool] = {}
+
+    class DummyService:
+        def __init__(self, *_, **__):
+            self.service = None
+
+        def _build_service(self) -> None:
+            called["build"] = has_app_context()
+            self.service = object()
+
+        async def sync(self) -> None:
+            called["sync"] = True
+
+    monkeypatch.setattr(calendar_cog, "CalendarService", DummyService)
+
+    async def ready():
+        return None
+
+    bot = types.SimpleNamespace(wait_until_ready=ready)
+    cog = calendar_cog.CalendarCog(bot)
+
+    await cog.sync_loop()
+
+    assert called.get("build") is True
+    assert called.get("sync")


### PR DESCRIPTION
## Summary
- lazily create CalendarService only after entering Flask app context
- ensure calendar commands and loops call setup_service
- add tests for lazy init and app-context sync

## Testing
- `black --check .`
- `flake8`
- `pytest tests/test_calendar_cog.py tests/test_calendar_cog_context.py`


------
https://chatgpt.com/codex/tasks/task_e_68984720cf188324815697630b29ff65