### PR TITLE
Ensure reminder autopilot uses Flask app context

### DIFF
--- a/bot/cogs/reminder_autopilot.py
+++ b/bot/cogs/reminder_autopilot.py
@@ -16,6 +16,7 @@ from mongo_service import get_collection
 from utils import poster_generator
 from utils.event_helpers import parse_event_time
 from bot.dm_utils import get_dm_image
+from main_app import app
 
 
 def is_opted_out(user_id: int) -> bool:
@@ -88,14 +89,15 @@ class ReminderAutopilot(commands.Cog):
         window_end = now + timedelta(minutes=11)
 
         try:
-            service = get_service(self.calendar_settings)
-            events = list_upcoming_events(
-                service,
-                time_min=window_start,
-                time_max=window_end,
-                max_results=50,
-                settings=self.calendar_settings,
-            )
+            with app.app_context():
+                service = get_service(self.calendar_settings)
+                events = list_upcoming_events(
+                    service,
+                    time_min=window_start,
+                    time_max=window_end,
+                    max_results=50,
+                    settings=self.calendar_settings,
+                )
             mapped_events = []
             for ev in events:
                 doc = get_collection("events").find_one({"google_id": ev.get("id")})

--- a/tests/test_reminder_autopilot_context.py
+++ b/tests/test_reminder_autopilot_context.py
@@ -4,6 +4,7 @@ import sys
 import types
 
 import pytest
+from flask import current_app
 
 services_pkg = types.ModuleType("services")
 services_pkg.__path__ = [str(pathlib.Path(__file__).resolve().parents[1] / "services")]
@@ -12,14 +13,65 @@ sys.modules["services"] = services_pkg
 autopilot_mod = importlib.import_module("bot.cogs.reminder_autopilot")
 
 
+class DummyUser:
+    def __init__(self) -> None:
+        self.sent: str | None = None
+
+    async def send(self, msg: str) -> None:
+        self.sent = msg
+
+
 @pytest.mark.asyncio
-async def test_reminder_autopilot_runs_without_app_context(monkeypatch):
-    monkeypatch.setattr(autopilot_mod.tasks.Loop, "start", lambda self: None)
-    bot = types.SimpleNamespace()
+async def test_reminder_autopilot_sends_with_app_context(monkeypatch):
+    monkeypatch.setattr(autopilot_mod.tasks.Loop, "start", lambda self, *a, **k: None)
+
+    user = DummyUser()
+
+    async def fetch_user(uid: int):
+        return user
+
+    bot = types.SimpleNamespace(fetch_user=fetch_user)
     cog = autopilot_mod.ReminderAutopilot(bot)
 
-    monkeypatch.setattr(autopilot_mod, "get_service", lambda settings: object())
-    monkeypatch.setattr(autopilot_mod, "list_upcoming_events", lambda *a, **k: [])
     monkeypatch.setattr(autopilot_mod, "is_production", lambda: True)
+    monkeypatch.setattr(autopilot_mod, "is_opted_out", lambda _uid: False)
+    monkeypatch.setattr(
+        autopilot_mod.ReminderAutopilot, "get_user_language", lambda self, uid: "en"
+    )
+    monkeypatch.setattr(autopilot_mod.Config, "REMINDER_ROLE_ID", 0, raising=False)
+
+    class EventsCol:
+        def find_one(self, query):  # pragma: no cover - simple stub
+            return {"_id": "1", "google_id": "abc", "title": "Test Event"}
+
+    class ParticipantsCol:
+        def find(self, query):  # pragma: no cover - simple stub
+            return [{"user_id": "123"}]
+
+    class RemindersSentCol:
+        def find_one(self, query):  # pragma: no cover - simple stub
+            return None
+
+        def insert_one(self, doc):  # pragma: no cover - simple stub
+            self.inserted = doc
+
+    def fake_get_collection(name):  # pragma: no cover - simple stub
+        mapping = {
+            "events": EventsCol(),
+            "event_participants": ParticipantsCol(),
+            "reminders_sent": RemindersSentCol(),
+        }
+        return mapping.get(name, types.SimpleNamespace(find_one=lambda q: None))
+
+    monkeypatch.setattr(autopilot_mod, "get_collection", fake_get_collection)
+
+    def fake_list_upcoming_events(service, **kwargs):
+        current_app.name  # will raise if context missing
+        return [{"id": "abc", "title": "Test Event"}]
+
+    monkeypatch.setattr(autopilot_mod, "get_service", lambda settings: object())
+    monkeypatch.setattr(autopilot_mod, "list_upcoming_events", fake_list_upcoming_events)
+    monkeypatch.setattr(autopilot_mod, "t", lambda key, title, lang: f"Reminder: {title}")
 
     await cog.run_reminder_check()
+    assert user.sent == "Reminder: Test Event"


### PR DESCRIPTION
## Summary
- import Flask `app` into reminder_autopilot
- wrap Google Calendar calls in `run_reminder_check` with `app.app_context()`
- add integration test ensuring reminders run with active app context

## Testing
- `black --check .`
- `flake8`
- `pytest tests/test_reminder_autopilot_context.py` *(fails: ModuleNotFoundError: No module named 'schedule')*

------
https://chatgpt.com/codex/tasks/task_e_68984b04efb48324b7ee5b2bf44dce41