### PR TITLE
Add range options to upcoming event listings

### DIFF
--- a/bot/dm_scheduler.py
+++ b/bot/dm_scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import Awaitable, Callable
 
 from services.calendar_service import CalendarService
@@ -20,7 +21,10 @@ class DMReminderScheduler:
 
     async def tick(self) -> None:
         """Check for upcoming events and send DMs via callback."""
-        events = await self.service.list_upcoming_events()
+        now = datetime.utcnow().replace(tzinfo=timezone.utc)
+        start = now + timedelta(minutes=10)
+        end = start + timedelta(minutes=1)
+        events = await self.service.list_upcoming_events(start=start, end=end, max_results=50)
         for ev in events:
             participants = self.service.events.database["event_participants"].find(
                 {"event_id": ev.get("_id")}

--- a/services/calendar_service.py
+++ b/services/calendar_service.py
@@ -206,12 +206,27 @@ class CalendarService:
         end = start + timedelta(days=1)
         return await self._get_range(start, end)
 
-    async def list_upcoming_events(self) -> list[dict]:
-        """Return events starting roughly 10 minutes from now."""
-        now = datetime.utcnow().replace(tzinfo=timezone.utc)
-        start = now + timedelta(minutes=10)
-        end = start + timedelta(minutes=1)
-        return await self._get_range(start, end)
+    async def list_upcoming_events(
+        self,
+        *,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        max_results: int | None = None,
+    ) -> list[dict]:
+        """Return upcoming events within the given range.
+
+        Parameters are optional and default to events starting roughly
+        10 minutes from now lasting one minute.
+        """
+        if start is None:
+            now = datetime.utcnow().replace(tzinfo=timezone.utc)
+            start = now + timedelta(minutes=10)
+        if end is None:
+            end = start + timedelta(minutes=1)
+        events = await self._get_range(start, end)
+        if max_results is not None:
+            events = events[:max_results]
+        return events
 
 
 __all__ = ["CalendarService", "SyncTokenExpired"]

--- a/tests/test_calendar_service.py
+++ b/tests/test_calendar_service.py
@@ -1,0 +1,55 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from services.calendar_service import CalendarService
+
+
+class DummyCollection:
+    database = {}
+
+
+@pytest.mark.asyncio
+async def test_list_upcoming_events_uses_params(monkeypatch):
+    service = CalendarService(
+        events_collection=DummyCollection(), tokens_collection=DummyCollection()
+    )
+
+    called = {}
+
+    async def fake_get_range(self, start, end):  # noqa: D401
+        called["start"] = start
+        called["end"] = end
+        return [{"id": 1}, {"id": 2}, {"id": 3}]
+
+    monkeypatch.setattr(CalendarService, "_get_range", fake_get_range, raising=False)
+
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 2, tzinfo=timezone.utc)
+    events = await service.list_upcoming_events(start=start, end=end, max_results=2)
+
+    assert called["start"] == start
+    assert called["end"] == end
+    assert len(events) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_upcoming_events_defaults(monkeypatch):
+    service = CalendarService(
+        events_collection=DummyCollection(), tokens_collection=DummyCollection()
+    )
+
+    called = {}
+
+    async def fake_get_range(self, start, end):  # noqa: D401
+        called["start"] = start
+        called["end"] = end
+        return []
+
+    monkeypatch.setattr(CalendarService, "_get_range", fake_get_range, raising=False)
+
+    now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    await service.list_upcoming_events()
+
+    assert timedelta(minutes=9) < called["start"] - now < timedelta(minutes=11)
+    assert called["end"] - called["start"] == timedelta(minutes=1)

--- a/tests/test_dm_scheduler.py
+++ b/tests/test_dm_scheduler.py
@@ -68,7 +68,7 @@ async def test_tick_sends_reminders():
         def __init__(self):
             self.events = FakeEventsCollection()
 
-        async def list_upcoming_events(self):
+        async def list_upcoming_events(self, *, start=None, end=None, max_results=None):
             return [
                 {
                     "_id": 1,
@@ -107,7 +107,7 @@ async def test_tick_avoids_duplicate_dms():
         def __init__(self):
             self.events = FakeEventsCollection()
 
-        async def list_upcoming_events(self):
+        async def list_upcoming_events(self, *, start=None, end=None, max_results=None):
             return [
                 {
                     "_id": 99,


### PR DESCRIPTION
## Summary
- allow specifying start/end/max_results for CalendarService.list_upcoming_events
- ensure DM reminder scheduler queries with explicit time window and limit
- add tests exercising new list_upcoming_events parameters

## Testing
- `black --check .`
- `flake8`
- `pytest` *(fails: ModuleNotFoundError: No module named 'googleapiclient')*


------
https://chatgpt.com/codex/tasks/task_e_689898fa17ec83248a5e7602bd179ef4